### PR TITLE
Fixes error 'android.view.ContextThemeWrapper cannot be cast to android.app.Activity'

### DIFF
--- a/android/src/main/java/com/documentscanner/DocumentScannerViewManager.java
+++ b/android/src/main/java/com/documentscanner/DocumentScannerViewManager.java
@@ -3,6 +3,9 @@ package com.documentscanner;
 import android.app.Activity;
 import android.util.Log;
 
+import android.content.Context;
+import android.content.ContextWrapper;
+
 import com.documentscanner.views.MainView;
 import com.documentscanner.views.OpenNoteCameraView;
 import com.facebook.react.bridge.Callback;
@@ -23,6 +26,14 @@ import javax.annotation.Nullable;
 
 public class DocumentScannerViewManager extends ViewGroupManager<MainView>{
 
+    private static Activity unwrap(Context context) {
+        while (!(context instanceof Activity) && context instanceof ContextWrapper) {
+            context = ((ContextWrapper) context).getBaseContext();
+        }
+
+        return (Activity) context;
+    }
+
     public static final String REACT_CLASS = "DocumentScanner";
     private MainView view = null;
 
@@ -34,7 +45,7 @@ public class DocumentScannerViewManager extends ViewGroupManager<MainView>{
     @Override
     protected MainView createViewInstance(final ThemedReactContext reactContext) {
        //OpenNoteCameraView view = new OpenNoteCameraView(reactContext, -1, reactContext.getCurrentActivity());
-        MainView.createInstance(reactContext,(Activity) reactContext.getBaseContext());
+        MainView.createInstance(reactContext,(Activity) unwrap(reactContext.getBaseContext()));
 
         view = MainView.getInstance();
         view.setOnProcessingListener(new OpenNoteCameraView.OnProcessingListener() {


### PR DESCRIPTION
I'm trying to use this library within an app built with expo and ejected to expokit.
When I try to use the DocumentScanner component in my .tsx file I get the error you can see in the screenshot.
I fixed the error by making a couple of changes in 'DocumentScannerViewManager.java', following the suggestion from https://stackoverflow.com/questions/51640154/android-view-contextthemewrapper-cannot-be-cast-to-android-app-activity.

![Screenshot 2019-03-19 at 14 07 22](https://user-images.githubusercontent.com/16187074/54608232-95a57b00-4a50-11e9-9a58-ab3de2e8b8d8.png)
