### PR TITLE
fix issue Black screen in arm64-v8a

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,18 +26,23 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 28
+    buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
-        ndk {
-            abiFilters "armeabi-v7a", "x86"
+    }
+    splits {
+        abi {
+            reset()
+            universalApk false  // If true, also generate a universal APK
+            include "armeabi-v7a", "x86", "arm64-v8a", 'x86_64'
         }
     }
+
     // lintOptions {
     //     abortOnError false
     //     warning 'InvalidPackage'
@@ -45,13 +50,12 @@ android {
 }
 
 dependencies {
-    //compile project(':openCVLibrary310').projectDir = new File(rootProject.projectDir,'../node_modules/react-native-documentscanner-android/android')
-    compile project(':openCVLibrary310')
-    compile "com.android.support:appcompat-v7:23.0.1"
-    compile "com.facebook.react:react-native:0.19.+"
-    compile 'com.google.zxing:core:3.0.1'
-    compile 'com.android.support:design:23.4.0'
-    compile 'org.piwik.sdk:piwik-sdk:0.0.4'
-    compile 'com.nostra13.universalimageloader:universal-image-loader:1.9.5'
-    compile 'us.feras.mdv:markdownview:1.1.0'
+    implementation project(':openCVLibrary310')
+    implementation "com.android.support:appcompat-v7:28.0.0"
+    implementation "com.facebook.react:react-native:0.19.+"
+    implementation 'com.google.zxing:core:3.0.1'
+    implementation 'com.android.support:design:28.0.0'
+    implementation 'org.piwik.sdk:piwik-sdk:0.0.4'
+    implementation 'com.nostra13.universalimageloader:universal-image-loader:1.9.5'
+    implementation 'us.feras.mdv:markdownview:1.1.0'
 }


### PR DESCRIPTION
I added libopencv_java3.so for arm64-v8a

<img width="461" alt="Screenshot 2019-07-10 at 12 14 01 AM" src="https://user-images.githubusercontent.com/10397772/60909183-cc292f00-a2a7-11e9-8012-007108c689dc.png">

this is my package.json if you want to use it temporarily while author repair it
```
"react": "^16.8.1",
"react-native": "^0.58.4",
"react-native-documentscanner-android": "git+https://github.com/thongdn/react-native-documentscanner-android.git#develop",
```